### PR TITLE
Added no-only rule for tests

### DIFF
--- a/lib/rules/no-only.js
+++ b/lib/rules/no-only.js
@@ -1,0 +1,92 @@
+// https://astexplorer.net/ is your friend
+
+const BLOCKS = ['describe', 'it'];
+const DISALLOWED = ['only'];
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    fixable: true,
+    docs: {
+      description: 'Disallow `.only` blocks in tests',
+      category: 'Error',
+      recommended: true
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          blocks: {
+            type: 'array',
+            items: {
+              type: 'string'
+            },
+            uniqueItems: true
+          },
+          disallowed: {
+            type: 'array',
+            items: {
+              type: 'string'
+            },
+            uniqueItems: true
+          },
+          fix: {
+            type: 'boolean'
+          }
+        },
+        additionalProperties: false
+      }
+    ],
+    messages: {
+      noOnly: '{{item}} not permitted'
+    }
+  },
+
+  create: function (context) {
+    const options = context.options[0] || {};
+    const blocks = options.blocks || BLOCKS;
+    const disallowed = options.disallowed || DISALLOWED;
+    const fix = !!options.fix;
+
+    return {
+      Identifier(node) {
+        const parent = node.parent && node.parent.object;
+        if (!parent) {
+          return;
+        }
+
+        if (!disallowed.includes(node.name)) {
+          return;
+        }
+
+        const callPath = getCallPath(node.parent).join('.');
+
+        if (!blocks.find(b => callPath.split(b)[0] === '')) {
+          return;
+        }
+
+        console.log(callPath);
+
+        const [start, end] = node.range;
+
+        context.report({
+          node,
+          ruleId: 'ti/no-only',
+          messageId: 'noOnly',
+          data: { item: callPath },
+          fix: fix ? f => f.removeRange([start - 1, end]) : undefined
+        });
+      }
+    };
+  }
+};
+
+function getCallPath(node, path = []) {
+  if (node) {
+    const nodeName = node.name || (node.property && node.property.name);
+    if (node.object) return getCallPath(node.object, [nodeName, ...path]);
+    if (node.callee) return getCallPath(node.callee, path);
+    return [nodeName, ...path];
+  }
+  return path;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thoughtindustries/eslint-plugin-ti",
-  "version": "1.0.1",
+  "version": "1.1.1",
   "description": "Rules specific to Thought Industries",
   "keywords": [
     "eslint",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "eslint-plugin-ti",
+  "name": "@thoughtindustries/eslint-plugin-ti",
   "version": "1.0.1",
   "description": "Rules specific to Thought Industries",
   "keywords": [

--- a/tests/lib/rules/no-only.js
+++ b/tests/lib/rules/no-only.js
@@ -1,0 +1,54 @@
+const rule = require('../../../lib/rules/no-only');
+const RuleTester = require('eslint').RuleTester;
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2018 } });
+const options = [{}];
+
+ruleTester.run('no-only', rule, {
+  valid: [
+    {
+      code: 'describe("fake test", () => {})',
+      filename: 'describe-test.spec.js',
+      options
+    },
+    {
+      code: 'it("should be a fake test", () => {})',
+      filename: 'it-test.spec.js',
+      options
+    }
+  ],
+  invalid: [
+    {
+      code: 'describe.only("fake test", () => {})',
+      options,
+      filename: 'describe-test.spec.js',
+      errors: [{ message: 'describe.only not permitted' }]
+    },
+    {
+      code: 'it.only("should be a fake test", () => {})',
+      options,
+      filename: 'it-test.spec.js',
+      errors: [{ messageId: 'noOnly' }]
+    },
+    {
+      code: 'describe("fake nested", () => {it.only("should be a fake test", () => {})})',
+      options: [{ fix: true }],
+      output: 'describe("fake nested", () => {it("should be a fake test", () => {})})',
+      filename: 'describe-it-test.spec.js',
+      errors: [{ messageId: 'noOnly' }]
+    },
+    {
+      code: 'describe.only("fake nested", () => {it.only("should be a fake test", () => {})})',
+      options: [{ fix: true }],
+      output: 'describe("fake nested", () => {it("should be a fake test", () => {})})',
+      filename: 'describe-it-test.spec.js',
+      errors: [{ message: 'describe.only not permitted' }, { message: 'it.only not permitted' }]
+    },
+    {
+      code: 'it.only("should be a fake test", () => {})',
+      output: 'it("should be a fake test", () => {})',
+      filename: 'fix-it-test.spec.js',
+      options: [{ fix: true }],
+      errors: [{ message: 'it.only not permitted' }]
+    }
+  ]
+});

--- a/tests/lib/rules/require-typename.js
+++ b/tests/lib/rules/require-typename.js
@@ -1,11 +1,9 @@
-const { parse } = require('graphql');
 const rule = require('../../../lib/rules/require-typename');
 const RuleTester = require('eslint').RuleTester;
 const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2018 } });
 const options = [{}];
 
 ruleTester.run('require-typename', rule, {
-  valid: [],
   valid: [
     {
       code: 'const x = gql`query { greetings { __typename, hello } }`',


### PR DESCRIPTION
Adding rule for `no-only` to replace the file `lint-tests.sh`.

It also adds the organization prefix (`@thoughtindustries`) that I apparently forgot to add before.

Finally, it removes an unused variable and a duplicate prop from `require-typename`.

If approved, I'll make the needed changes to the `ti` repo.