### PR TITLE
Adding checks for using the new db layer

### DIFF
--- a/lib/rules/use-db-layer.js
+++ b/lib/rules/use-db-layer.js
@@ -1,0 +1,56 @@
+// https://astexplorer.net/ is your friend
+
+const utils = require('../utils');
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Force use of database layer if it is available' ,
+      category: 'Error',
+      recommended: true
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          tables: {
+            type: 'array',
+            items: {
+              type: 'string'
+            },
+            uniqueItems: true
+          }
+        },
+        additionalProperties: false
+      }
+    ],
+    messages: {
+      useDbLayer: 'Use the {{table}} database layer.'
+    }
+  },
+
+  create: function (context) {
+    if (!(context.options || []).length || !context.options[0].tables) {
+      throw new Error('`tables` must be set');
+    }
+
+    const { tables } = context.options[0];
+
+    return {
+      'CallExpression[callee.property][callee.property.name="table"]'(
+        node
+      ) {
+        const { table } = utils.getTableOrMessageId(node.arguments[0], node);
+
+        if (tables.includes(table)) {
+          context.report({
+            node,
+            messageId: 'useDbLayer',
+            data: { table }
+          });
+        }
+      }
+    };
+  }
+};

--- a/tests/lib/rules/use-db-layer.js
+++ b/tests/lib/rules/use-db-layer.js
@@ -1,0 +1,39 @@
+const rule = require('../../../lib/rules/use-db-layer');
+const RuleTester = require('eslint').RuleTester;
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2018 } });
+const options = [{ tables: ['translations'] }];
+
+ruleTester.run('use-db-layer', rule, {
+  valid: [
+    {
+      code: `async function dbFunc() {
+        const tableName = 'learningPaths';
+        await r.pool.run(r.table(tableName).update({ updatedAt: r.now() }));
+      }`,
+      options
+    },
+    {
+      code: `async function dbFunc() {
+        await r.pool.run(r.table('learningPaths').update({ updatedAt: r.now() }));
+      }`,
+      options
+    }
+  ],
+  invalid: [
+    {
+      code: `async function dbFunc() {
+        await r.pool.run(r.table('translations').update({ updatedAt: r.now() }));
+      }`,
+      options,
+      errors: [{ messageId: 'useDbLayer', data: { table: 'translations' } }]
+    },
+    {
+      code: `async function dbFunc() {
+        const tableName = 'translations';
+        await r.pool.run(r.table(tableName).update({ updatedAt: r.now() }));
+      }`,
+      options,
+      errors: [{ messageId: 'useDbLayer', data: { table: 'translations' } }]
+    }
+  ]
+});


### PR DESCRIPTION
May be a bit naive, but it checks to see if a `.table(tableName)` has been moved to the new database layer.