### PR TITLE
Fix for table callees without any arguments

### DIFF
--- a/lib/rules/use-db-layer.js
+++ b/lib/rules/use-db-layer.js
@@ -41,14 +41,16 @@ module.exports = {
       'CallExpression[callee.property][callee.property.name="table"]'(
         node
       ) {
-        const { table } = utils.getTableOrMessageId(node.arguments[0], node);
+        if (node.arguments && node.arguments.length) {
+          const { table } = utils.getTableOrMessageId(node.arguments[0], node);
 
-        if (tables.includes(table)) {
-          context.report({
-            node,
-            messageId: 'useDbLayer',
-            data: { table }
-          });
+          if (tables.includes(table)) {
+            context.report({
+              node,
+              messageId: 'useDbLayer',
+              data: { table }
+            });
+          }
         }
       }
     };


### PR DESCRIPTION
Checking for `node.arguments.length` otherwise `getTableOrMessageId` throws an error.