### PR TITLE
Check if object properties exist before looping through them

### DIFF
--- a/lib/rules/use-db-layer.js
+++ b/lib/rules/use-db-layer.js
@@ -65,7 +65,20 @@ module.exports = {
 
         if (node.arguments?.[1]?.type === 'ArrayExpression') {
           node.arguments[1].elements.forEach(arg => {
-            arg.properties.forEach(prop => {
+            if (arg.properties) {
+              arg.properties.forEach(prop => {
+                if (utils.getProp(prop, 'value.callee.object.name') === 'r') {
+                  context.report({
+                    node,
+                    messageId: 'convertRethinkdbFunctions'
+                  });
+                }
+              });
+            }
+          });
+        } else if (node.arguments?.[1]?.type === 'ObjectExpression') {
+          if (node.arguments[1].properties) {
+            node.arguments[1].properties.forEach(prop => {
               if (utils.getProp(prop, 'value.callee.object.name') === 'r') {
                 context.report({
                   node,
@@ -73,16 +86,7 @@ module.exports = {
                 });
               }
             });
-          });
-        } else if (node.arguments?.[1]?.type === 'ObjectExpression') {
-          node.arguments[1].properties.forEach(prop => {
-            if (utils.getProp(prop, 'value.callee.object.name') === 'r') {
-              context.report({
-                node,
-                messageId: 'convertRethinkdbFunctions'
-              });
-            }
-          })
+          }
         }
       }
     };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thoughtindustries/eslint-plugin-ti",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Rules specific to Thought Industries",
   "keywords": [
     "eslint",


### PR DESCRIPTION
In cases of using a variable (e.g. `r.users.insert(r, [var1, var2])`) eslint would throw an error since `arg.properties` didn't exist. This checks for the existence of `arg.properties` first.