### PR TITLE
Added rule add-pg-updated-at

### DIFF
--- a/lib/rules/add-pg-updated-at.js
+++ b/lib/rules/add-pg-updated-at.js
@@ -1,0 +1,59 @@
+module.exports = {
+  meta: {
+    type: 'problem',
+    fixable: false,
+    docs: {
+      description: 'Add `updatedAt` to custom update query',
+      category: 'Error',
+      recommended: true
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {},
+        additionalProperties: false
+      }
+    ],
+    messages: {
+      addPgUpdatedAt: 'Add `updatedAt` to custom update query'
+    }
+  },
+
+  create: function (context) {
+    return {
+      'CallExpression[callee.property][callee.property.name="query"]'(
+        node
+      ) {
+        const arg = node.arguments?.[0] || {};
+        let isUpdate = false;
+        let hasUpdatedAt = false;
+
+        if (arg.type === 'TemplateLiteral') {
+          if (arg.quasis[0].value.raw.trim().toLowerCase().startsWith('update')) {
+            isUpdate = true;
+            arg.quasis.forEach(q => {
+              if (q.value.raw.includes('updated_at')) {
+                hasUpdatedAt = true;
+              }
+            });
+          }
+        } else {
+          if (arg?.value?.trim().toLowerCase().startsWith('update')) {
+            isUpdate = true;
+            if (arg.value.includes('updated_at')) {
+              hasUpdatedAt = true;
+            }
+          }
+        }
+
+        if (isUpdate && !hasUpdatedAt) {
+          context.report({
+            node,
+            ruleId: 'ti/add-pg-updated-at',
+            messageId: 'addPgUpdatedAt'
+          });
+        }
+      }
+    };
+  }
+};

--- a/tests/lib/rules/add-pg-updated-at.js
+++ b/tests/lib/rules/add-pg-updated-at.js
@@ -1,0 +1,156 @@
+const rule = require('../../../lib/rules/add-pg-updated-at');
+const RuleTester = require('eslint').RuleTester;
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2021 } });
+const options = [{}];
+
+ruleTester.run('add-pg-updated-at', rule, {
+  valid: [
+    {
+      code: `function update(db, id, data) {
+        return wrapper({
+          rethinkdb: async () => {
+              await db.rethinkdb.pool.run(
+                db.rethinkdb
+                  .table('someTable')
+                  .get(id)
+                  .update(
+                    {
+                      data,
+                      updatedAt: db.rethinkdb.now()
+                    }
+                  )
+              );
+          },
+          postgres: async () => {
+            const escaped = db.postgres.escape(JSON.stringify(data));
+            await db.postgres.query(
+              \`
+              UPDATE ti.someTable m
+              SET data = data || \${escaped}::jsonb,
+              updated_at = $updatedAt
+              WHERE m.id = $id
+              \`,
+              {
+                bind: { id, updatedAt: new Date() },
+                type: db.postgres.QueryTypes.UPDATE,
+                raw: true,
+                plain: false
+              }
+            );
+      
+            return await postgresBase.findById(db.postgres, 'someTable', id);
+          }
+        });
+      }`,
+      options
+    },
+    {
+      code: `function update(db, id, data) {
+        return wrapper({
+          rethinkdb: async () => {
+              await db.rethinkdb.pool.run(
+                db.rethinkdb
+                  .table('someTable')
+                  .get(id)
+                  .update(
+                    {
+                      data,
+                      updatedAt: db.rethinkdb.now()
+                    }
+                  )
+              );
+          },
+          postgres: async () => {
+            const escaped = db.postgres.escape(JSON.stringify(data));
+            await db.postgres.query(
+              'UPDATE ti.someTable m SET data = data || \${escaped}::jsonb, updated_at = $updatedAt WHERE m.id = $id',
+              {
+                bind: { id, updatedAt: new Date() },
+                type: db.postgres.QueryTypes.UPDATE,
+                raw: true,
+                plain: false
+              }
+            );
+      
+            return await postgresBase.findById(db.postgres, 'someTable', id);
+          }
+        });
+      }`,
+      options
+    },
+    {
+      code: `function update(db, id, data) {
+        return wrapper({
+          rethinkdb: async () => {
+              await db.rethinkdb.pool.run(
+                db.rethinkdb
+                  .table('someTable')
+                  .get(id)
+                  .update(
+                    {
+                      data,
+                      updatedAt: db.rethinkdb.now()
+                    }
+                  )
+              );
+          },
+          postgres: async () => {
+            const escaped = db.postgres.escape(JSON.stringify(data));
+            await db.postgres.query(
+              'SELECT FROM ti.someTable',
+              {
+                type: db.postgres.QueryTypes.SELECT,
+                raw: true,
+                plain: false
+              }
+            );
+      
+            return await postgresBase.findById(db.postgres, 'someTable', id);
+          }
+        });
+      }`,
+      options
+    }
+  ],
+  invalid: [
+    {
+      code: `function update(db, id, data) {
+        return wrapper({
+          rethinkdb: async () => {
+              await db.rethinkdb.pool.run(
+                db.rethinkdb
+                  .table('someTable')
+                  .get(id)
+                  .update(
+                    {
+                      data,
+                      updatedAt: db.rethinkdb.now()
+                    }
+                  )
+              );
+          },
+          postgres: async () => {
+            const escaped = db.postgres.escape(JSON.stringify(data));
+            await db.postgres.query(
+              \`
+              UPDATE ti.someTable m
+              SET data = data || \${escaped}::jsonb
+              WHERE m.id = $id
+              \`,
+              {
+                bind: { id },
+                type: db.postgres.QueryTypes.UPDATE,
+                raw: true,
+                plain: false
+              }
+            );
+      
+            return await postgresBase.findById(db.postgres, 'someTable', id);
+          }
+        });
+      }`,
+      options,
+      errors: [{ messageId: 'addPgUpdatedAt' }]
+    }
+  ]
+});


### PR DESCRIPTION
Custom update queries need `updated_at` added to them manually since Sequelize doesn't add them. This rule checks for the string `updated_at` in update queries.