### PR TITLE
Add rule add-updated-at-on-duplicate

### DIFF
--- a/lib/rules/add-updated-at-on-duplicate.js
+++ b/lib/rules/add-updated-at-on-duplicate.js
@@ -1,0 +1,45 @@
+module.exports = {
+  meta: {
+    type: 'problem',
+    fixable: false,
+    docs: {
+      description: 'Add `updatedAt` to `updateOnDuplicate`',
+      category: 'Error',
+      recommended: true
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {},
+        additionalProperties: false
+      }
+    ],
+    messages: {
+      addUpdatedAtOnDuplicate: 'Add `updatedAt` to `updateOnDuplicate`'
+    }
+  },
+
+  create: function (context) {
+    return {
+      'CallExpression[callee.property][callee.property.name="bulkCreate"]'(
+        node
+      ) {
+        const arg = node.arguments?.[1];
+
+        if (arg) {
+          const updateOnDuplicate = arg.properties.find(p => p.key.name === 'updateOnDuplicate');
+          if (
+            updateOnDuplicate &&
+            !updateOnDuplicate.value.elements.find(e => e.value === 'updatedAt')
+          ) {
+            context.report({
+              node,
+              ruleId: 'ti/add-updated-at-on-duplicate',
+              messageId: 'addUpdatedAtOnDuplicate'
+            });
+          }
+        }
+      }
+    };
+  }
+};

--- a/tests/lib/rules/add-updated-at-on-duplicate.js
+++ b/tests/lib/rules/add-updated-at-on-duplicate.js
@@ -1,0 +1,75 @@
+const rule = require('../../../lib/rules/add-updated-at-on-duplicate');
+const RuleTester = require('eslint').RuleTester;
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2021 } });
+const options = [{}];
+
+ruleTester.run('add-updated-at-on-duplicate', rule, {
+  valid: [
+    {
+      code: `function update(db, data) {
+        return wrapper({
+          postgres: async () => {
+            const model = postgresBase.getModel(db.postgres, 'table');
+            const results = await model.bulkCreate(data, {
+              updateOnDuplicate: [
+                'something',
+                'somethingElse',
+                'updatedAt'
+              ]
+            });
+      
+            return toPlainObject(results);
+          }
+        });
+      }`,
+      options
+    },
+    {
+      code: `function update(db, data) {
+        return wrapper({
+          postgres: async () => {
+            const model = postgresBase.getModel(db.postgres, 'table');
+            const results = await model.bulkCreate(data);
+      
+            return toPlainObject(results);
+          }
+        });
+      }`,
+      options
+    },
+    {
+      code: `function update(db, data) {
+        return wrapper({
+          postgres: async () => {
+            const model = postgresBase.getModel(db.postgres, 'table');
+            const results = await model.bulkCreate(data, { some: 'prop' });
+      
+            return toPlainObject(results);
+          }
+        });
+      }`,
+      options
+    }
+  ],
+  invalid: [
+    {
+      code: `function update(db, data) {
+        return wrapper({
+          postgres: async () => {
+            const model = postgresBase.getModel(db.postgres, 'table');
+            const results = await model.bulkCreate(data, {
+              updateOnDuplicate: [
+                'something',
+                'somethingElse'
+              ]
+            });
+      
+            return toPlainObject(results);
+          }
+        });
+      }`,
+      options,
+      errors: [{ messageId: 'addUpdatedAtOnDuplicate' }]
+    }
+  ]
+});


### PR DESCRIPTION
Add a rule to check for `updatedAt` on `bulkCreate` with the property `updateOnDuplicate` since Sequelize won't update it otherwise.