### PR TITLE
Move dependencies from devDependencies to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@thoughtindustries/eslint-plugin-ti",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@thoughtindustries/eslint-plugin-ti",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "ISC",
       "dependencies": {
         "glob": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thoughtindustries/eslint-plugin-ti",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Rules specific to Thought Industries",
   "keywords": [
     "eslint",
@@ -19,13 +19,13 @@
     "glob": "^7.2.0",
     "i": "^0.3.7",
     "prettier": "^2.4.1",
-    "requireindex": "^1.2.0"
+    "putout": "^28.0.1",
+    "requireindex": "^1.2.0",
+    "try-catch": "^3.0.1"
   },
   "devDependencies": {
     "eslint": "^7.32.0",
-    "mocha": "^10.1.0",
-    "putout": "^28.0.1",
-    "try-catch": "^3.0.1"
+    "mocha": "^10.1.0"
   },
   "peerDependencies": {
     "graphql": "*"


### PR DESCRIPTION
Because putout and try-catch were in devDependencies, they weren't found when trying to use the plugin in the ti repo. They had to be moved to dependencies.