### PR TITLE
Fix id-helper rule. Stop it from flagging base.insert.

### DIFF
--- a/lib/rules/id-helper.js
+++ b/lib/rules/id-helper.js
@@ -21,7 +21,7 @@ module.exports = {
 
   create: function (context) {
     return {
-      'CallExpression[callee.property][callee.object.name!="dbBatch"][callee.property.name=/(insert)/]'(
+      'CallExpression[callee.property][callee.object.name!=/(dbBatch|base)/][callee.property.name="insert"]'(
         node
       ) {
         if (!alreadyWrapped(node)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thoughtindustries/eslint-plugin-ti",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Rules specific to Thought Industries",
   "keywords": [
     "eslint",

--- a/tests/lib/rules/id-helper.js
+++ b/tests/lib/rules/id-helper.js
@@ -29,6 +29,13 @@ ruleTester.run('id-helper', rule, {
         });
       }`,
       options
+    },
+    {
+      code: `module.exports = {
+        insert: base.insert('pages'),
+        insertAndReturnFirstRow: base.insertAndReturnFirstRow('pages')
+      }`,
+      options
     }
   ],
   invalid: [


### PR DESCRIPTION
The `id-helper` rule was flagging `base.insert('someTable')` in the module exports. This stops it from doing that.