### PR TITLE
Fixes the `Cannot read property 'find' of undefined` error

### DIFF
--- a/lib/rules/add-updated-at-on-duplicate.js
+++ b/lib/rules/add-updated-at-on-duplicate.js
@@ -30,6 +30,7 @@ module.exports = {
           const updateOnDuplicate = arg.properties.find(p => p.key.name === 'updateOnDuplicate');
           if (
             updateOnDuplicate &&
+            updateOnDuplicate.value.elements &&
             !updateOnDuplicate.value.elements.find(e => e.value === 'updatedAt')
           ) {
             context.report({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thoughtindustries/eslint-plugin-ti",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "Rules specific to Thought Industries",
   "keywords": [
     "eslint",

--- a/tests/lib/rules/add-updated-at-on-duplicate.js
+++ b/tests/lib/rules/add-updated-at-on-duplicate.js
@@ -49,6 +49,19 @@ ruleTester.run('add-updated-at-on-duplicate', rule, {
         });
       }`,
       options
+    },
+    {
+      code: `function insertOrUpdate(db, expirations) {
+        return wrapper({
+          postgres: async () => {
+            const model = postgresBase.getModel(db.postgres, 'someTable');
+            await model.bulkCreate(expirations, {
+              updateOnDuplicate: Object.keys(expirations[0])
+            });
+          }
+        });
+      }`,
+      options
     }
   ],
   invalid: [


### PR DESCRIPTION
When hitting `updateOnDuplicate: Object.keys()` the plugin was throwing an error because the value wasn't an array. This updates it to skip Object.keys and only look in arrays.