### PR TITLE
Added new rule that requires 'r' in base repo functions

### DIFF
--- a/lib/rules/require-r.js
+++ b/lib/rules/require-r.js
@@ -1,0 +1,37 @@
+module.exports = {
+  meta: {
+    type: 'problem',
+    fixable: false,
+    docs: {
+      description: 'Must pass in `r` to the repository functions',
+      category: 'Error',
+      recommended: true
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {},
+        additionalProperties: false
+      }
+    ],
+    messages: {
+      requireR: 'Must pass in `r` to the repository functions'
+    }
+  },
+
+  create: function (context) {
+    return {
+      'CallExpression[callee.property.name=/findById|insert|insertAndReturnFirstRow|update|updateAndReturnFirstRow|getAllByCompanyId|getAttributesByIds|batchUpdate|destroyById|updateByScopeAndReturnFirstRow|findBySlug|findByCompanyAndSlugs/]'(
+        node
+      ) {
+        if (node.arguments?.[0]?.name !== 'r') {
+          context.report({
+            node,
+            ruleId: 'ti/require-r',
+            messageId: 'requireR'
+          });
+        }
+      }
+    };
+  }
+};

--- a/lib/rules/require-r.js
+++ b/lib/rules/require-r.js
@@ -21,7 +21,18 @@ module.exports = {
 
   create: function (context) {
     return {
-      'CallExpression[callee.property.name=/findById|insert|insertAndReturnFirstRow|update|updateAndReturnFirstRow|getAllByCompanyId|getAttributesByIds|batchUpdate|destroyById|updateByScopeAndReturnFirstRow|findBySlug|findByCompanyAndSlugs/]'(
+      'CallExpression[callee.object.object.name="r"][callee.property.name=/findById|insert|insertAndReturnFirstRow|update|updateAndReturnFirstRow|getAllByCompanyId|getAttributesByIds|batchUpdate|destroyById|updateByScopeAndReturnFirstRow|findBySlug|findByCompanyAndSlugs/]'(
+        node
+      ) {
+        if (node.arguments?.[0]?.name !== 'r') {
+          context.report({
+            node,
+            ruleId: 'ti/require-r',
+            messageId: 'requireR'
+          });
+        }
+      },
+      'CallExpression[callee.object.object.property.name="r"][callee.property.name=/findById|insert|insertAndReturnFirstRow|update|updateAndReturnFirstRow|getAllByCompanyId|getAttributesByIds|batchUpdate|destroyById|updateByScopeAndReturnFirstRow|findBySlug|findByCompanyAndSlugs/]'(
         node
       ) {
         if (node.arguments?.[0]?.name !== 'r') {

--- a/lib/rules/require-r.js
+++ b/lib/rules/require-r.js
@@ -24,7 +24,7 @@ module.exports = {
       'CallExpression[callee.object.object.name="r"][callee.property.name=/findById|insert|insertAndReturnFirstRow|update|updateAndReturnFirstRow|getAllByCompanyId|getAttributesByIds|batchUpdate|destroyById|updateByScopeAndReturnFirstRow|findBySlug|findByCompanyAndSlugs/]'(
         node
       ) {
-        if (node.arguments?.[0]?.name !== 'r') {
+        if (node.arguments?.[0]?.name !== 'r' && node.arguments?.[0]?.property?.name !== 'r') {
           context.report({
             node,
             ruleId: 'ti/require-r',
@@ -35,7 +35,7 @@ module.exports = {
       'CallExpression[callee.object.object.property.name="r"][callee.property.name=/findById|insert|insertAndReturnFirstRow|update|updateAndReturnFirstRow|getAllByCompanyId|getAttributesByIds|batchUpdate|destroyById|updateByScopeAndReturnFirstRow|findBySlug|findByCompanyAndSlugs/]'(
         node
       ) {
-        if (node.arguments?.[0]?.name !== 'r') {
+        if (node.arguments?.[0]?.name !== 'r' && node.arguments?.[0]?.property?.name !== 'r') {
           context.report({
             node,
             ruleId: 'ti/require-r',

--- a/lib/rules/require-r.js
+++ b/lib/rules/require-r.js
@@ -24,25 +24,23 @@ module.exports = {
       'CallExpression[callee.object.object.name="r"][callee.property.name=/findById|insert|insertAndReturnFirstRow|update|updateAndReturnFirstRow|getAllByCompanyId|getAttributesByIds|batchUpdate|destroyById|updateByScopeAndReturnFirstRow|findBySlug|findByCompanyAndSlugs/]'(
         node
       ) {
-        if (node.arguments?.[0]?.name !== 'r' && node.arguments?.[0]?.property?.name !== 'r') {
-          context.report({
-            node,
-            ruleId: 'ti/require-r',
-            messageId: 'requireR'
-          });
-        }
+        ifMissingR(node, context);
       },
       'CallExpression[callee.object.object.property.name="r"][callee.property.name=/findById|insert|insertAndReturnFirstRow|update|updateAndReturnFirstRow|getAllByCompanyId|getAttributesByIds|batchUpdate|destroyById|updateByScopeAndReturnFirstRow|findBySlug|findByCompanyAndSlugs/]'(
         node
       ) {
-        if (node.arguments?.[0]?.name !== 'r' && node.arguments?.[0]?.property?.name !== 'r') {
-          context.report({
-            node,
-            ruleId: 'ti/require-r',
-            messageId: 'requireR'
-          });
-        }
+        ifMissingR(node, context);
       }
     };
   }
 };
+
+function ifMissingR(node, context) {
+  if (node.arguments?.[0]?.name !== 'r' && node.arguments?.[0]?.property?.name !== 'r') {
+    context.report({
+      node,
+      ruleId: 'ti/require-r',
+      messageId: 'requireR'
+    });
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thoughtindustries/eslint-plugin-ti",
-  "version": "1.6.4",
+  "version": "1.7.0",
   "description": "Rules specific to Thought Industries",
   "keywords": [
     "eslint",

--- a/tests/lib/rules/require-r.js
+++ b/tests/lib/rules/require-r.js
@@ -1,0 +1,37 @@
+const rule = require('../../../lib/rules/require-r');
+const RuleTester = require('eslint').RuleTester;
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2021 } });
+const options = [{}];
+
+ruleTester.run('require-r', rule, {
+  valid: [
+    {
+      code: `async function getUsers(ids) {
+        const users = await r.users.findById(r, ids);
+      }`,
+      options
+    },
+    {
+      code: `async function getUsers(slug) {
+        const users = await this.r.users.findBySlug(r, slug);
+      }`,
+      options
+    }
+  ],
+  invalid: [
+    {
+      code: `async function getUsers(ids) {
+        const users = await r.users.findById(ids);
+      }`,
+      options,
+      errors: [{ messageId: 'requireR' }]
+    },
+    {
+      code: `async function getUsers(slug) {
+        const users = await this.r.users.findBySlug(slug);
+      }`,
+      options,
+      errors: [{ messageId: 'requireR' }]
+    }
+  ]
+});

--- a/tests/lib/rules/require-r.js
+++ b/tests/lib/rules/require-r.js
@@ -13,7 +13,7 @@ ruleTester.run('require-r', rule, {
     },
     {
       code: `async function getUsers(slug) {
-        const users = await this.r.users.findBySlug(r, slug);
+        const users = await this.r.users.findBySlug(this.r, slug);
       }`,
       options
     },

--- a/tests/lib/rules/require-r.js
+++ b/tests/lib/rules/require-r.js
@@ -16,6 +16,12 @@ ruleTester.run('require-r', rule, {
         const users = await this.r.users.findBySlug(r, slug);
       }`,
       options
+    },
+    {
+      code: `async function getUsers(slug) {
+        notARepoFunction.insert(slug);
+      }`,
+      options
     }
   ],
   invalid: [


### PR DESCRIPTION
It can be easy to forget the `r` in repo functions. This rule requires `r` as the first argument.