### PR TITLE
Fix updateOnDuplicate properties undefined error

### DIFF
--- a/lib/rules/add-updated-at-on-duplicate.js
+++ b/lib/rules/add-updated-at-on-duplicate.js
@@ -27,7 +27,9 @@ module.exports = {
         const arg = node.arguments?.[1];
 
         if (arg) {
-          const updateOnDuplicate = arg.properties.find(p => p.key.name === 'updateOnDuplicate');
+          const updateOnDuplicate = (arg.properties || []).find(
+            p => p.key.name === 'updateOnDuplicate'
+          );
           if (
             updateOnDuplicate &&
             updateOnDuplicate.value.elements &&

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thoughtindustries/eslint-plugin-ti",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Rules specific to Thought Industries",
   "keywords": [
     "eslint",

--- a/tests/lib/rules/add-updated-at-on-duplicate.js
+++ b/tests/lib/rules/add-updated-at-on-duplicate.js
@@ -41,6 +41,20 @@ ruleTester.run('add-updated-at-on-duplicate', rule, {
       code: `function update(db, data) {
         return wrapper({
           postgres: async () => {
+            const result = await postgresBase
+            .getModel(db.postgres, tableName)
+            .bulkCreate(newData, ops);
+            
+            return result;
+          }
+        });
+      }`,
+      options
+    },
+    {
+      code: `function update(db, data) {
+        return wrapper({
+          postgres: async () => {
             const model = postgresBase.getModel(db.postgres, 'table');
             const results = await model.bulkCreate(data, { some: 'prop' });
       


### PR DESCRIPTION
The plugin was throwing an error because properties wasn't defined and we were calling `find` on it. This PR fixes that issue.